### PR TITLE
Fix stretched animated cursors from single-representation themes

### DIFF
--- a/CursorEngine/MACCursorActions.m
+++ b/CursorEngine/MACCursorActions.m
@@ -197,7 +197,7 @@ BOOL applyThemeForIdentifier(NSDictionary *cursor, NSString *identifier, BOOL re
     CGFloat fd = frameDuration.doubleValue;
 
     BOOL sheetsRebuilt = NO;
-    if (fc > MACMaxFrameCount && images.count > 1) {
+    if (fc > MACMaxFrameCount && images.count >= 1) {
         NSUInteger targetCount = MACMaxFrameCount;
         NSMutableArray *rebuiltSheets = [NSMutableArray arrayWithCapacity:images.count];
         BOOL allRebuilt = YES;
@@ -243,8 +243,7 @@ BOOL applyThemeForIdentifier(NSDictionary *cursor, NSString *identifier, BOOL re
         }
     }
 
-    if (!sheetsRebuilt &&
-        ((fc > MACMaxFrameCount && images.count >= 1) || (images.count == 1 && fc > 1))) {
+    if (!sheetsRebuilt && fc > MACMaxFrameCount && images.count >= 1) {
         CGImageRef firstSheet = (__bridge CGImageRef)images[0];
         NSUInteger sheetHeight = CGImageGetHeight(firstSheet);
         NSUInteger frameHeight = sheetHeight / fc;


### PR DESCRIPTION
Fixes the stretched-animated-cursor bug described in #22 (the unresolved half of #18).

### Problem

`CGSRegisterCursorWithImages` expects one image per **scale**, each a vertical strip containing every frame — macOS's own cursors follow this convention (the stock arrow registers as `frames=1, imgs=4`: one frame, four scales).

The apply path instead split the sprite sheet into one image per **frame** whenever a theme had exactly one representation and more than one frame:

```objc
if (!sheetsRebuilt &&
    ((fc > MACMaxFrameCount && images.count >= 1) || (images.count == 1 && fc > 1))) {
```

A 12-frame `32x384` sheet was therefore registered as 12 separate `32x32` images. WindowServer read each as a 12-frame strip, making every frame `32x2.67px` stretched to fill 32×32 points.

Single-representation themes are the norm for imported Windows `.ani` packs whose source art has no higher-resolution variant, so those applied distorted every time. Themes with two or more representations never entered the branch — which is why supplying a 2× asset appeared to resolve it.

### Changes

- **Drop the `images.count == 1 && fc > 1` clause.** A well-formed sheet needs no transformation before registration; it is already in the exact shape the API wants.
- **Relax the sheet-rebuild guard from `images.count > 1` to `>= 1`.** The rebuild path above already handles over-length animations correctly by rebuilding a *downsampled sheet* rather than splitting, preserving the per-scale structure. Requiring more than one representation meant single-representation themes above `MACMaxFrameCount` skipped it and fell through to the splitter. With this change the splitter is only reachable when the rebuild was needed and genuinely failed, which is its proper role as a degraded fallback.

No behaviour change for themes with 2+ representations, and none for static cursors.

### Verification

Built the patched helper and applied the same single-representation theme (12 frames, `32x384`, no 2× asset) that reproduces the bug on v2.3.0, then read the registration back via `SLSGetRegisteredCursorDataSize` / `SLSCopyRegisteredCursorImages`:

| | `imgs` registered | `bytes` |
|---|---|---|
| v2.3.0 | 12 | 4096 (one frame) |
| this PR | 1 | 49152 (full 12-frame strip) |

`4096` is exactly `32*32*4`, one frame; the full strip is `32*384*4 = 49152`. Confirmed visually — the cursor renders at its authored proportions with no 2× workaround, and animates at the correct rate.

Tested on macOS 26.3.1 (25D771280a), Apple Silicon, including the Tahoe `ArrowS` / `IBeamS` alias path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
