### PR TITLE
Add adaptive cursor colors and system appearance switching

### DIFF
--- a/CursorEngine/MACAutoSwitch.h
+++ b/CursorEngine/MACAutoSwitch.h
@@ -11,12 +11,17 @@ extern NSString * const MACAutoSwitchAppliedThemeDidChangeNotification;
 extern NSString * MACAutoSwitchThemePathForIdentifier(NSString *identifier);
 
 extern NSString * _Nullable MACAutoSwitchResolveScheduleTheme(NSArray * _Nullable rules, NSInteger nowMinutes);
+extern NSString * _Nullable MACAutoSwitchResolveAppearanceTheme(NSArray * _Nullable rules, BOOL darkAppearance);
 extern NSInteger MACAutoSwitchMinutesUntilNextBoundary(NSArray * _Nullable rules, NSInteger nowMinutes);
 extern NSInteger MACAutoSwitchCurrentMinuteOfDay(void);
 extern NSDictionary * _Nullable MACAutoSwitchReadConfig(void);
+extern BOOL MACAutoSwitchUsesSystemAppearance(NSDictionary * _Nullable config);
+extern BOOL MACAutoSwitchSystemUsesDarkAppearance(void);
+extern BOOL MACAutoSwitchUsesColorAdjustment(NSDictionary * _Nullable config);
 extern NSString * _Nullable MACAutoSwitchResolveThemeIdentifier(NSDictionary * _Nullable config, NSInteger nowMinutes);
 
 extern NSString * _Nullable MACAutoSwitchPendingIdentifier(NSString * _Nullable desired, NSString * _Nullable current);
 extern BOOL MACAutoSwitchApplyIfNeeded(void);
+extern BOOL MACAutoSwitchReapplyCurrentConfiguration(void);
 
 NS_ASSUME_NONNULL_END

--- a/CursorEngine/MACAutoSwitch.m
+++ b/CursorEngine/MACAutoSwitch.m
@@ -1,6 +1,7 @@
 #import "MACAutoSwitch.h"
 #import "MACCursorDefs.h"
 #import "MACCursorActions.h"
+#import <AppKit/AppKit.h>
 
 NSString * const MACPreferencesAutoSwitchRulesKey = @"MACAutoSwitchRules";
 NSString * const MACAutoSwitchDidChangeNotification = @"MACAutoSwitchDidChange";
@@ -60,6 +61,33 @@ NSString * _Nullable MACAutoSwitchResolveScheduleTheme(NSArray * _Nullable rules
     return passedTheme ?: latestTheme;
 }
 
+NSString * _Nullable MACAutoSwitchResolveAppearanceTheme(NSArray * _Nullable rules, BOOL darkAppearance) {
+    if (![rules isKindOfClass:[NSArray class]] || rules.count == 0) return nil;
+
+    NSString *desiredRole = darkAppearance ? @"night" : @"day";
+    NSMutableArray<NSDictionary *> *usableRules = [NSMutableArray array];
+
+    for (id candidate in rules) {
+        NSString *theme = nil;
+        NSInteger minutes = 0;
+        if (!usableRule(candidate, &theme, &minutes)) continue;
+
+        NSDictionary *dict = (NSDictionary *)candidate;
+        if ([dict[@"role"] isKindOfClass:[NSString class]]
+            && [dict[@"role"] isEqualToString:desiredRole]) {
+            return theme;
+        }
+        [usableRules addObject:dict];
+    }
+
+    [usableRules sortUsingComparator:^NSComparisonResult(NSDictionary *left, NSDictionary *right) {
+        return [left[@"startMinutes"] compare:right[@"startMinutes"]];
+    }];
+    NSDictionary *fallback = darkAppearance ? usableRules.lastObject : usableRules.firstObject;
+    return [fallback[@"themeIdentifier"] isKindOfClass:[NSString class]]
+        ? fallback[@"themeIdentifier"] : nil;
+}
+
 NSInteger MACAutoSwitchMinutesUntilNextBoundary(NSArray * _Nullable rules, NSInteger nowMinutes) {
     if (![rules isKindOfClass:[NSArray class]] || rules.count == 0) return -1;
 
@@ -96,10 +124,275 @@ NSDictionary * _Nullable MACAutoSwitchReadConfig(void) {
     return (NSDictionary *)parsed;
 }
 
+BOOL MACAutoSwitchUsesSystemAppearance(NSDictionary * _Nullable config) {
+    return [config isKindOfClass:[NSDictionary class]]
+        && [config[@"followsSystemAppearance"] boolValue];
+}
+
+BOOL MACAutoSwitchSystemUsesDarkAppearance(void) {
+    CFStringRef globalDomain = CFSTR(".GlobalPreferences");
+    CFPreferencesSynchronize(globalDomain,
+                             kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
+    CFPropertyListRef rawValue = CFPreferencesCopyValue(
+        CFSTR("AppleInterfaceStyle"), globalDomain,
+        kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
+
+    BOOL isDark = rawValue
+        && CFGetTypeID(rawValue) == CFStringGetTypeID()
+        && [(__bridge NSString *)rawValue caseInsensitiveCompare:@"Dark"] == NSOrderedSame;
+    if (rawValue) CFRelease(rawValue);
+    return isDark;
+}
+
+BOOL MACAutoSwitchUsesColorAdjustment(NSDictionary * _Nullable config) {
+    return [config isKindOfClass:[NSDictionary class]]
+        && [config[@"colorAdjustmentEnabled"] boolValue];
+}
+
 NSString * _Nullable MACAutoSwitchResolveThemeIdentifier(NSDictionary * _Nullable config, NSInteger nowMinutes) {
     if (![config isKindOfClass:[NSDictionary class]]) return nil;
     if (![config[@"enabled"] boolValue]) return nil;
+    if (MACAutoSwitchUsesSystemAppearance(config)) {
+        return MACAutoSwitchResolveAppearanceTheme(
+            config[@"scheduleRules"], MACAutoSwitchSystemUsesDarkAppearance());
+    }
     return MACAutoSwitchResolveScheduleTheme(config[@"scheduleRules"], nowMinutes);
+}
+
+static NSColor *colorFromHexString(NSString *hex, NSColor *fallback) {
+    NSString *clean = [[hex ?: @"" stringByReplacingOccurrencesOfString:@"#" withString:@""]
+        uppercaseString];
+    if (clean.length != 6) return fallback;
+
+    unsigned int value = 0;
+    if (![[NSScanner scannerWithString:clean] scanHexInt:&value]) return fallback;
+    return [NSColor colorWithSRGBRed:((value >> 16) & 0xFF) / 255.0
+                               green:((value >> 8) & 0xFF) / 255.0
+                                blue:(value & 0xFF) / 255.0
+                               alpha:1.0];
+}
+
+static NSColor *resolvedTargetColor(NSDictionary *config) {
+    NSColor *base = colorFromHexString(config[@"baseColorHex"],
+        [NSColor colorWithSRGBRed:1.0 green:131.0 / 255.0 blue:0 alpha:1]);
+    if (![config[@"followsSystemAccent"] boolValue]) return base;
+
+    NSColor *accent = [[NSColor controlAccentColor] colorUsingColorSpace:NSColorSpace.sRGBColorSpace];
+    if (!accent) return base;
+
+    CGFloat amount = [config[@"accentAdaptivity"] respondsToSelector:@selector(doubleValue)]
+        ? [config[@"accentAdaptivity"] doubleValue] : 1.0;
+    amount = MIN(MAX(amount, 0), 1);
+
+    NSColor *rgbBase = [base colorUsingColorSpace:NSColorSpace.sRGBColorSpace] ?: base;
+    return [NSColor colorWithSRGBRed:rgbBase.redComponent * (1 - amount) + accent.redComponent * amount
+                               green:rgbBase.greenComponent * (1 - amount) + accent.greenComponent * amount
+                                blue:rgbBase.blueComponent * (1 - amount) + accent.blueComponent * amount
+                               alpha:1.0];
+}
+
+static NSString *hexStringForColor(NSColor *color) {
+    NSColor *rgb = [color colorUsingColorSpace:NSColorSpace.sRGBColorSpace] ?: color;
+    return [NSString stringWithFormat:@"%02X%02X%02X",
+        (int)lround(MIN(MAX(rgb.redComponent, 0), 1) * 255),
+        (int)lround(MIN(MAX(rgb.greenComponent, 0), 1) * 255),
+        (int)lround(MIN(MAX(rgb.blueComponent, 0), 1) * 255)];
+}
+
+static NSBitmapImageRep *bitmapForPNGData(NSData *data) {
+    NSImage *image = [[NSImage alloc] initWithData:data];
+    if (!image) return nil;
+
+    NSRect proposed = NSMakeRect(0, 0, image.size.width, image.size.height);
+    CGImageRef source = [image CGImageForProposedRect:&proposed context:nil hints:nil];
+    if (!source) return nil;
+    return [[NSBitmapImageRep alloc] initWithCGImage:source];
+}
+
+static BOOL detectFillColor(NSData *pngData, CGFloat *outRed, CGFloat *outGreen, CGFloat *outBlue) {
+    NSBitmapImageRep *bitmap = bitmapForPNGData(pngData);
+    if (!bitmap) return NO;
+
+    NSUInteger bucketCount = 32 * 32 * 32;
+    NSUInteger *counts = calloc(bucketCount, sizeof(NSUInteger));
+    if (!counts) return NO;
+
+    unsigned char *pixels = bitmap.bitmapData;
+    NSInteger rowBytes = bitmap.bytesPerRow;
+    for (NSInteger y = 0; y < bitmap.pixelsHigh; y++) {
+        unsigned char *row = pixels + y * rowBytes;
+        for (NSInteger x = 0; x < bitmap.pixelsWide; x++) {
+            unsigned char *pixel = row + x * 4;
+            if (pixel[3] < 230) continue;
+
+            CGFloat red = pixel[0] / 255.0;
+            CGFloat green = pixel[1] / 255.0;
+            CGFloat blue = pixel[2] / 255.0;
+            CGFloat maximum = MAX(red, MAX(green, blue));
+            CGFloat minimum = MIN(red, MIN(green, blue));
+            if (minimum > 0.82 && maximum - minimum < 0.12) continue;
+
+            NSUInteger key = (pixel[0] >> 3) << 10
+                | (pixel[1] >> 3) << 5
+                | (pixel[2] >> 3);
+            counts[key]++;
+        }
+    }
+
+    NSUInteger bestKey = 0;
+    NSUInteger bestCount = 0;
+    for (NSUInteger key = 0; key < bucketCount; key++) {
+        if (counts[key] > bestCount) {
+            bestKey = key;
+            bestCount = counts[key];
+        }
+    }
+    free(counts);
+    if (bestCount == 0) return NO;
+
+    *outRed = (((bestKey >> 10) & 31) * 8 + 4) / 255.0;
+    *outGreen = (((bestKey >> 5) & 31) * 8 + 4) / 255.0;
+    *outBlue = ((bestKey & 31) * 8 + 4) / 255.0;
+    return YES;
+}
+
+static NSData *recoloredPNGData(NSData *pngData,
+                                CGFloat sourceRed, CGFloat sourceGreen, CGFloat sourceBlue,
+                                NSColor *targetColor) {
+    NSBitmapImageRep *bitmap = bitmapForPNGData(pngData);
+    if (!bitmap) return pngData;
+
+    NSColor *target = [targetColor colorUsingColorSpace:NSColorSpace.sRGBColorSpace] ?: targetColor;
+    CGFloat targetRed = target.redComponent;
+    CGFloat targetGreen = target.greenComponent;
+    CGFloat targetBlue = target.blueComponent;
+
+    unsigned char *pixels = bitmap.bitmapData;
+    NSInteger rowBytes = bitmap.bytesPerRow;
+    for (NSInteger y = 0; y < bitmap.pixelsHigh; y++) {
+        unsigned char *row = pixels + y * rowBytes;
+        for (NSInteger x = 0; x < bitmap.pixelsWide; x++) {
+            unsigned char *pixel = row + x * 4;
+            CGFloat alpha = pixel[3] / 255.0;
+            if (alpha < 0.35) continue;
+
+            CGFloat red = pixel[0] / 255.0;
+            CGFloat green = pixel[1] / 255.0;
+            CGFloat blue = pixel[2] / 255.0;
+            CGFloat redDelta = red - sourceRed;
+            CGFloat greenDelta = green - sourceGreen;
+            CGFloat blueDelta = blue - sourceBlue;
+            CGFloat distance = sqrt(redDelta * redDelta
+                + greenDelta * greenDelta + blueDelta * blueDelta);
+            CGFloat colorWeight = MIN(MAX(1.0 - distance / 0.42, 0), 1);
+            CGFloat alphaWeight = MIN(MAX((alpha - 0.35) / 0.55, 0), 1);
+            CGFloat weight = colorWeight * alphaWeight;
+            if (weight <= 0) continue;
+
+            pixel[0] = (unsigned char)lround((red * (1 - weight) + targetRed * weight) * 255);
+            pixel[1] = (unsigned char)lround((green * (1 - weight) + targetGreen * weight) * 255);
+            pixel[2] = (unsigned char)lround((blue * (1 - weight) + targetBlue * weight) * 255);
+        }
+    }
+
+    return [bitmap representationUsingType:NSBitmapImageFileTypePNG properties:@{}] ?: pngData;
+}
+
+static NSString *preparedColorAdjustedThemePath(NSString *identifier,
+                                                 NSString *sourcePath,
+                                                 NSDictionary *config) {
+    NSColor *targetColor = resolvedTargetColor(config);
+    NSDictionary *attributes = [[NSFileManager defaultManager]
+        attributesOfItemAtPath:sourcePath error:nil];
+    long long size = [attributes[NSFileSize] longLongValue];
+    long long modified = (long long)[attributes[NSFileModificationDate] timeIntervalSince1970];
+    NSString *signature = [NSString stringWithFormat:@"%@-%@-%lld-%lld",
+        identifier, hexStringForColor(targetColor), size, modified];
+    NSString *safeSignature = [signature stringByReplacingOccurrencesOfString:@"/" withString:@"_"];
+
+    NSURL *cachesURL = [[NSFileManager defaultManager]
+        URLsForDirectory:NSCachesDirectory inDomains:NSUserDomainMask].firstObject;
+    NSString *cacheDirectory = [cachesURL.path
+        stringByAppendingPathComponent:@"com.writronic.MaCursor/AdaptiveCursors"];
+    NSString *cachePath = [[cacheDirectory stringByAppendingPathComponent:safeSignature]
+        stringByAppendingPathExtension:@"cursor"];
+    if ([[NSFileManager defaultManager] fileExistsAtPath:cachePath]) return cachePath;
+
+    NSData *sourceData = [NSData dataWithContentsOfFile:sourcePath];
+    if (!sourceData) return sourcePath;
+
+    NSError *plistError = nil;
+    NSMutableDictionary *root = [NSPropertyListSerialization
+        propertyListWithData:sourceData
+        options:NSPropertyListMutableContainersAndLeaves
+        format:NULL
+        error:&plistError];
+    if (![root isKindOfClass:[NSMutableDictionary class]]) return sourcePath;
+
+    NSMutableDictionary *cursors = root[@"Cursors"];
+    NSDictionary *arrow = cursors[@"com.apple.coregraphics.Arrow"];
+    NSArray *arrowRepresentations = arrow[@"Representations"];
+    NSData *sample = [arrowRepresentations.lastObject isKindOfClass:[NSData class]]
+        ? arrowRepresentations.lastObject : nil;
+    CGFloat sourceRed = 0, sourceGreen = 0, sourceBlue = 0;
+    if (!sample || !detectFillColor(sample, &sourceRed, &sourceGreen, &sourceBlue)) {
+        return sourcePath;
+    }
+
+    [cursors enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
+        if (![value isKindOfClass:[NSMutableDictionary class]]) return;
+        NSMutableDictionary *cursor = (NSMutableDictionary *)value;
+        NSArray *representations = cursor[@"Representations"];
+        if (![representations isKindOfClass:[NSArray class]]) return;
+
+        NSMutableArray *updated = [NSMutableArray arrayWithCapacity:representations.count];
+        for (id representation in representations) {
+            if ([representation isKindOfClass:[NSData class]]) {
+                [updated addObject:recoloredPNGData(
+                    representation, sourceRed, sourceGreen, sourceBlue, targetColor)];
+            } else {
+                [updated addObject:representation];
+            }
+        }
+        cursor[@"Representations"] = updated;
+    }];
+
+    NSError *serializationError = nil;
+    NSData *adjustedData = [NSPropertyListSerialization
+        dataWithPropertyList:root
+        format:NSPropertyListBinaryFormat_v1_0
+        options:0
+        error:&serializationError];
+    if (!adjustedData) return sourcePath;
+
+    [[NSFileManager defaultManager] createDirectoryAtPath:cacheDirectory
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:nil];
+    if (![adjustedData writeToFile:cachePath options:NSDataWritingAtomic error:nil]) {
+        return sourcePath;
+    }
+
+    NSArray<NSString *> *cachedFiles = [[NSFileManager defaultManager]
+        contentsOfDirectoryAtPath:cacheDirectory error:nil];
+    if (cachedFiles.count > 12) {
+        NSArray<NSString *> *sorted = [cachedFiles
+            sortedArrayUsingComparator:^NSComparisonResult(NSString *left, NSString *right) {
+                NSString *leftPath = [cacheDirectory stringByAppendingPathComponent:left];
+                NSString *rightPath = [cacheDirectory stringByAppendingPathComponent:right];
+                NSDate *leftDate = [[[NSFileManager defaultManager]
+                    attributesOfItemAtPath:leftPath error:nil] fileModificationDate];
+                NSDate *rightDate = [[[NSFileManager defaultManager]
+                    attributesOfItemAtPath:rightPath error:nil] fileModificationDate];
+                return [rightDate compare:leftDate];
+            }];
+        for (NSUInteger index = 12; index < sorted.count; index++) {
+            [[NSFileManager defaultManager]
+                removeItemAtPath:[cacheDirectory stringByAppendingPathComponent:sorted[index]]
+                error:nil];
+        }
+    }
+    return cachePath;
 }
 
 NSString * _Nullable MACAutoSwitchPendingIdentifier(NSString * _Nullable desired, NSString * _Nullable current) {
@@ -108,30 +401,38 @@ NSString * _Nullable MACAutoSwitchPendingIdentifier(NSString * _Nullable desired
     return desired;
 }
 
-BOOL MACAutoSwitchApplyIfNeeded(void) {
+static BOOL applyCurrentConfiguration(BOOL force) {
     NSDictionary *config = MACAutoSwitchReadConfig();
     NSString *desired = MACAutoSwitchResolveThemeIdentifier(config, MACAutoSwitchCurrentMinuteOfDay());
 
     id stored = MACDefault(MACPreferencesAppliedCursorKey);
     NSString *current = [stored isKindOfClass:[NSString class]] ? (NSString *)stored : nil;
+    if (desired.length == 0 && (MACAutoSwitchUsesColorAdjustment(config) || force)) {
+        desired = current;
+    }
 
     NSString *pending = MACAutoSwitchPendingIdentifier(desired, current);
-    if (!pending) return NO;
+    if (!pending && !MACAutoSwitchUsesColorAdjustment(config) && !force) return NO;
+    NSString *targetIdentifier = pending ?: desired;
+    if (targetIdentifier.length == 0) return NO;
 
-    NSString *path = MACAutoSwitchThemePathForIdentifier(pending);
+    NSString *path = MACAutoSwitchThemePathForIdentifier(targetIdentifier);
     if (![[NSFileManager defaultManager] fileExistsAtPath:path]) {
         MMLog(BOLD YELLOW "Auto-switch target %s is missing on disk, keeping current cursor" RESET,
-              [pending UTF8String]);
+              [targetIdentifier UTF8String]);
         return NO;
+    }
+    if (MACAutoSwitchUsesColorAdjustment(config)) {
+        path = preparedColorAdjustedThemePath(targetIdentifier, path, config);
     }
 
     if (!applyThemeAtPath(path)) {
-        MMLog(BOLD RED "Auto-switch failed to apply %s" RESET, [pending UTF8String]);
+        MMLog(BOLD RED "Auto-switch failed to apply %s" RESET, [targetIdentifier UTF8String]);
         return NO;
     }
 
-    MACSetDefault(pending, MACPreferencesAppliedCursorKey);
-    MMLog(BOLD GREEN "Auto-switch applied %s" RESET, [pending UTF8String]);
+    MACSetDefault(targetIdentifier, MACPreferencesAppliedCursorKey);
+    MMLog(BOLD GREEN "Auto-switch applied %s" RESET, [targetIdentifier UTF8String]);
 
     [[NSDistributedNotificationCenter defaultCenter]
         postNotificationName:MACAutoSwitchAppliedThemeDidChangeNotification
@@ -139,4 +440,12 @@ BOOL MACAutoSwitchApplyIfNeeded(void) {
                     userInfo:nil
           deliverImmediately:YES];
     return YES;
+}
+
+BOOL MACAutoSwitchApplyIfNeeded(void) {
+    return applyCurrentConfiguration(NO);
+}
+
+BOOL MACAutoSwitchReapplyCurrentConfiguration(void) {
+    return applyCurrentConfiguration(YES);
 }

--- a/CursorEngine/MACCursorDaemon.m
+++ b/CursorEngine/MACCursorDaemon.m
@@ -297,6 +297,7 @@ void reconfigurationCallback(CGDirectDisplayID display,
 }
 
 static dispatch_source_t sScheduleTimer = NULL;
+static dispatch_source_t sAutoSwitchConfigTimer = NULL;
 
 static void rescheduleAutoSwitchTimer(void) {
     if (sScheduleTimer) {
@@ -307,6 +308,10 @@ static void rescheduleAutoSwitchTimer(void) {
     NSDictionary *config = MACAutoSwitchReadConfig();
     if (![config[@"enabled"] boolValue]) {
         MMLog(BOLD CYAN "Auto-switch disabled, no timer scheduled" RESET);
+        return;
+    }
+    if (MACAutoSwitchUsesSystemAppearance(config)) {
+        MMLog(BOLD CYAN "Auto-switch follows system appearance, no time timer scheduled" RESET);
         return;
     }
 
@@ -338,11 +343,57 @@ static void autoSwitchDidChangeCallback(CFNotificationCenterRef center,
     void *observer, CFNotificationName name, const void *object,
     CFDictionaryRef userInfo)
 {
-    MMLog(BOLD CYAN "Auto-switch config changed, re-resolving" RESET);
-    if (MACAutoSwitchApplyIfNeeded()) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (sAutoSwitchConfigTimer) {
+            dispatch_source_cancel(sAutoSwitchConfigTimer);
+            sAutoSwitchConfigTimer = NULL;
+        }
+
+        sAutoSwitchConfigTimer = dispatch_source_create(
+            DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
+        dispatch_source_set_timer(
+            sAutoSwitchConfigTimer,
+            dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)),
+            DISPATCH_TIME_FOREVER, 0);
+        dispatch_source_set_event_handler(sAutoSwitchConfigTimer, ^{
+            MMLog(BOLD CYAN "Auto-switch config changed, re-resolving" RESET);
+            if (MACAutoSwitchReapplyCurrentConfiguration()) {
+                forceCursorVisualRefresh();
+            }
+            rescheduleAutoSwitchTimer();
+            sAutoSwitchConfigTimer = NULL;
+        });
+        dispatch_resume(sAutoSwitchConfigTimer);
+    });
+}
+
+static void systemAppearanceDidChangeCallback(CFNotificationCenterRef center,
+    void *observer, CFNotificationName name, const void *object,
+    CFDictionaryRef userInfo)
+{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        NSDictionary *config = MACAutoSwitchReadConfig();
+        if (!MACAutoSwitchUsesSystemAppearance(config)) return;
+
+        MMLog(BOLD CYAN "System appearance changed, re-resolving cursor theme" RESET);
+        if (MACAutoSwitchApplyIfNeeded()) {
+            forceCursorVisualRefresh();
+        }
+    });
+}
+
+static void systemColorsDidChangeCallback(NSNotification *note) {
+    NSDictionary *config = MACAutoSwitchReadConfig();
+    BOOL followsAppearance = MACAutoSwitchUsesSystemAppearance(config);
+    BOOL followsAccent = MACAutoSwitchUsesColorAdjustment(config)
+        && [config[@"followsSystemAccent"] boolValue];
+    if (!followsAppearance && !followsAccent) return;
+
+    MMLog(BOLD CYAN "System colors changed, re-resolving cursor theme" RESET);
+    if (MACAutoSwitchReapplyCurrentConfiguration()) {
         forceCursorVisualRefresh();
     }
-    rescheduleAutoSwitchTimer();
 }
 
 static void shortcutsDidChangeCallback(CFNotificationCenterRef center,
@@ -441,6 +492,25 @@ void listener(void) {
         CFNotificationSuspensionBehaviorDeliverImmediately
     );
     MMLog(BOLD CYAN "Listening for Auto-switch config changes" RESET);
+
+    CFNotificationCenterAddObserver(
+        CFNotificationCenterGetDistributedCenter(),
+        NULL,
+        systemAppearanceDidChangeCallback,
+        CFSTR("AppleInterfaceThemeChangedNotification"),
+        NULL,
+        CFNotificationSuspensionBehaviorDeliverImmediately
+    );
+    MMLog(BOLD CYAN "Listening for System appearance changes" RESET);
+
+    [[NSNotificationCenter defaultCenter]
+        addObserverForName:NSSystemColorsDidChangeNotification
+        object:nil
+        queue:[NSOperationQueue mainQueue]
+        usingBlock:^(NSNotification *note) {
+            systemColorsDidChangeCallback(note);
+        }];
+    MMLog(BOLD CYAN "Listening for System accent color changes" RESET);
 
     [[[NSWorkspace sharedWorkspace] notificationCenter]
         addObserverForName:NSWorkspaceDidWakeNotification

--- a/MaCursor/Resources/l10n/de.lproj/Localizable.strings
+++ b/MaCursor/Resources/l10n/de.lproj/Localizable.strings
@@ -563,6 +563,13 @@
 
 /* Explanation of scheduled cursor switching in Cursor settings */
 "Pick a time and a cursor theme for each mode. MaCursor switches at those times and keeps that theme until the next one." = "Wählen Sie für jeden Modus eine Uhrzeit und ein Cursor-Design aus. MaCursor wechselt zu diesen Zeiten und behält das jeweilige Design bis zum nächsten Wechsel bei.";
+"Follow system appearance" = "Systemdarstellung folgen";
+"Pick a cursor theme for Light and Dark mode. MaCursor follows the macOS appearance automatically." = "Wählen Sie ein Cursor-Design für den hellen und dunklen Modus. MaCursor folgt automatisch der macOS-Darstellung.";
+"Custom cursor color" = "Eigene Cursorfarbe";
+"Base color" = "Grundfarbe";
+"Follow system accent color" = "Systemakzentfarbe folgen";
+"Accent adaptivity" = "Akzent-Anpassung";
+"The cursor fill follows your chosen color and, optionally, the macOS accent color. White outlines and shadows stay unchanged." = "Die Cursorfüllung folgt Ihrer gewählten Farbe und optional der macOS-Akzentfarbe. Weiße Konturen und Schatten bleiben unverändert.";
 
 /* Warning when both scheduled modes are given the same clock time */
 "Day mode and Night mode must start at different times, so the time was moved by one minute." = "Der Tagesmodus und der Nachtmodus müssen zu unterschiedlichen Zeiten beginnen, daher wurde die Uhrzeit um eine Minute verschoben.";

--- a/MaCursor/Resources/l10n/en.lproj/Localizable.strings
+++ b/MaCursor/Resources/l10n/en.lproj/Localizable.strings
@@ -575,6 +575,13 @@
 
 /* Explanation of scheduled cursor switching in Cursor settings */
 "Pick a time and a cursor theme for each mode. MaCursor switches at those times and keeps that theme until the next one." = "Pick a time and a cursor theme for each mode. MaCursor switches at those times and keeps that theme until the next one.";
+"Follow system appearance" = "Follow system appearance";
+"Pick a cursor theme for Light and Dark mode. MaCursor follows the macOS appearance automatically." = "Pick a cursor theme for Light and Dark mode. MaCursor follows the macOS appearance automatically.";
+"Custom cursor color" = "Custom cursor color";
+"Base color" = "Base color";
+"Follow system accent color" = "Follow system accent color";
+"Accent adaptivity" = "Accent adaptivity";
+"The cursor fill follows your chosen color and, optionally, the macOS accent color. White outlines and shadows stay unchanged." = "The cursor fill follows your chosen color and, optionally, the macOS accent color. White outlines and shadows stay unchanged.";
 
 /* Warning when both scheduled modes are given the same clock time */
 "Day mode and Night mode must start at different times, so the time was moved by one minute." = "Day mode and Night mode must start at different times, so the time was moved by one minute.";

--- a/MaCursor/SwiftUI/AppDelegate.swift
+++ b/MaCursor/SwiftUI/AppDelegate.swift
@@ -45,6 +45,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        MACAutoSwitchApplyIfNeeded()
         refreshHelperRegistrationIfNeeded()
     }
 

--- a/MaCursor/SwiftUI/Models/AutoSwitchRules.swift
+++ b/MaCursor/SwiftUI/Models/AutoSwitchRules.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 enum ScheduleRole: String, Codable, CaseIterable, Identifiable {
@@ -10,6 +11,13 @@ enum ScheduleRole: String, Codable, CaseIterable, Identifiable {
         switch self {
         case .day:   return String(localized: "Day mode")
         case .night: return String(localized: "Night mode")
+        }
+    }
+
+    var appearanceLabel: String {
+        switch self {
+        case .day:   return String(localized: "Light")
+        case .night: return String(localized: "Dark")
         }
     }
 
@@ -113,15 +121,30 @@ struct AppRule: Identifiable, Codable, Hashable {
 
 struct AutoSwitchConfig: Codable {
     var enabled: Bool
+    var followsSystemAppearance: Bool
+    var colorAdjustmentEnabled: Bool
+    var baseColorHex: String
+    var followsSystemAccent: Bool
+    var accentAdaptivity: Double
     var use24HourTime: Bool
     var scheduleRules: [ScheduleRule]
     var appRules: [AppRule]
 
     init(enabled: Bool = false,
+         followsSystemAppearance: Bool = false,
+         colorAdjustmentEnabled: Bool = false,
+         baseColorHex: String = "#FF8300",
+         followsSystemAccent: Bool = false,
+         accentAdaptivity: Double = 1.0,
          use24HourTime: Bool = AutoSwitchConfig.systemPrefers24HourTime(),
          scheduleRules: [ScheduleRule] = [],
          appRules: [AppRule] = []) {
         self.enabled = enabled
+        self.followsSystemAppearance = followsSystemAppearance
+        self.colorAdjustmentEnabled = colorAdjustmentEnabled
+        self.baseColorHex = CursorColorHex.normalized(baseColorHex) ?? "#FF8300"
+        self.followsSystemAccent = followsSystemAccent
+        self.accentAdaptivity = min(max(accentAdaptivity, 0), 1)
         self.use24HourTime = use24HourTime
         self.scheduleRules = scheduleRules
         self.appRules = appRules
@@ -130,6 +153,18 @@ struct AutoSwitchConfig: Codable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
+        followsSystemAppearance = try container.decodeIfPresent(
+            Bool.self, forKey: .followsSystemAppearance) ?? false
+        colorAdjustmentEnabled = try container.decodeIfPresent(
+            Bool.self, forKey: .colorAdjustmentEnabled) ?? false
+        baseColorHex = CursorColorHex.normalized(
+            try container.decodeIfPresent(String.self, forKey: .baseColorHex) ?? "#FF8300"
+        ) ?? "#FF8300"
+        followsSystemAccent = try container.decodeIfPresent(
+            Bool.self, forKey: .followsSystemAccent) ?? false
+        accentAdaptivity = min(max(
+            try container.decodeIfPresent(Double.self, forKey: .accentAdaptivity) ?? 1.0,
+            0), 1)
         use24HourTime = try container.decodeIfPresent(Bool.self, forKey: .use24HourTime)
             ?? AutoSwitchConfig.systemPrefers24HourTime()
         scheduleRules = try container.decodeIfPresent([ScheduleRule].self, forKey: .scheduleRules) ?? []
@@ -177,6 +212,9 @@ struct AutoSwitchConfig: Codable {
     }
 
     mutating func normalize() {
+        baseColorHex = CursorColorHex.normalized(baseColorHex) ?? "#FF8300"
+        accentAdaptivity = min(max(accentAdaptivity, 0), 1)
+
         var day = rule(for: .day)
         var night = rule(for: .night)
         day.role = .day
@@ -229,5 +267,36 @@ struct AutoSwitchConfig: Codable {
             userInfo: nil,
             deliverImmediately: true
         )
+    }
+}
+
+enum CursorColorHex {
+    static func normalized(_ value: String) -> String? {
+        let hex = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "#", with: "")
+            .uppercased()
+        guard hex.count == 6, UInt64(hex, radix: 16) != nil else { return nil }
+        return "#" + hex
+    }
+
+    static func color(from value: String) -> NSColor {
+        guard let hex = normalized(value),
+              let number = UInt64(hex.dropFirst(), radix: 16) else {
+            return NSColor(srgbRed: 1, green: 131 / 255, blue: 0, alpha: 1)
+        }
+        return NSColor(
+            srgbRed: CGFloat((number >> 16) & 0xFF) / 255,
+            green: CGFloat((number >> 8) & 0xFF) / 255,
+            blue: CGFloat(number & 0xFF) / 255,
+            alpha: 1
+        )
+    }
+
+    static func hex(from color: NSColor) -> String? {
+        guard let rgb = color.usingColorSpace(.sRGB) else { return nil }
+        let red = Int(round(min(max(rgb.redComponent, 0), 1) * 255))
+        let green = Int(round(min(max(rgb.greenComponent, 0), 1) * 255))
+        let blue = Int(round(min(max(rgb.blueComponent, 0), 1) * 255))
+        return String(format: "#%02X%02X%02X", red, green, blue)
     }
 }

--- a/MaCursor/SwiftUI/Views/CursorSettingsView.swift
+++ b/MaCursor/SwiftUI/Views/CursorSettingsView.swift
@@ -100,6 +100,41 @@ struct CursorSettingsView: View {
                 Text("When enabled, a soft drop shadow is drawn under the cursor, similar to the pointer shadow on Windows. The shadow appears while a cursor theme is applied.")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
+
+                Toggle("Custom cursor color", isOn: $autoSwitch.colorAdjustmentEnabled)
+                    .onChange(of: autoSwitch.colorAdjustmentEnabled) { _, _ in
+                        autoSwitch.save()
+                    }
+
+                if autoSwitch.colorAdjustmentEnabled {
+                    ColorPicker("Base color", selection: cursorColorBinding, supportsOpacity: false)
+
+                    Toggle("Follow system accent color", isOn: $autoSwitch.followsSystemAccent)
+                        .onChange(of: autoSwitch.followsSystemAccent) { _, _ in
+                            autoSwitch.save()
+                        }
+
+                    if autoSwitch.followsSystemAccent {
+                        HStack {
+                            Text("Accent adaptivity")
+
+                            Slider(value: $autoSwitch.accentAdaptivity, in: 0...1) { editing in
+                                if !editing {
+                                    autoSwitch.save()
+                                }
+                            }
+
+                            Text(autoSwitch.accentAdaptivity, format: .percent.precision(.fractionLength(0)))
+                                .monospacedDigit()
+                                .foregroundStyle(.secondary)
+                                .frame(width: 42, alignment: .trailing)
+                        }
+                    }
+
+                    Text("The cursor fill follows your chosen color and, optionally, the macOS accent color. White outlines and shadows stay unchanged.")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
             }
 
             Section("Automatic Switching") {
@@ -120,24 +155,37 @@ struct CursorSettingsView: View {
                     }
 
                 if autoSwitch.enabled {
-                    Picker("Time Format", selection: $autoSwitch.use24HourTime) {
-                        Text("AM/PM").tag(false)
-                        Text("24 hours").tag(true)
-                    }
-                    .pickerStyle(.radioGroup)
-                    .onChange(of: autoSwitch.use24HourTime) { _, _ in
-                        autoSwitch.save()
+                    Toggle("Follow system appearance", isOn: $autoSwitch.followsSystemAppearance)
+                        .onChange(of: autoSwitch.followsSystemAppearance) { _, _ in
+                            showTimeCollisionNotice = false
+                            autoSwitch.save()
+                        }
+
+                    if !autoSwitch.followsSystemAppearance {
+                        Picker("Time Format", selection: $autoSwitch.use24HourTime) {
+                            Text("AM/PM").tag(false)
+                            Text("24 hours").tag(true)
+                        }
+                        .pickerStyle(.radioGroup)
+                        .onChange(of: autoSwitch.use24HourTime) { _, _ in
+                            autoSwitch.save()
+                        }
                     }
 
                     ForEach(ScheduleRole.allCases) { role in
                         HStack(spacing: 10) {
-                            Label(role.label, systemImage: role.icon)
-                                .frame(width: 118, alignment: .leading)
-
-                            TimeOfDayField(
-                                minutes: timeBinding(for: role),
-                                use24Hour: autoSwitch.use24HourTime
+                            Label(
+                                autoSwitch.followsSystemAppearance ? role.appearanceLabel : role.label,
+                                systemImage: role.icon
                             )
+                            .frame(width: 118, alignment: .leading)
+
+                            if !autoSwitch.followsSystemAppearance {
+                                TimeOfDayField(
+                                    minutes: timeBinding(for: role),
+                                    use24Hour: autoSwitch.use24HourTime
+                                )
+                            }
 
                             Spacer(minLength: 6)
 
@@ -155,7 +203,7 @@ struct CursorSettingsView: View {
                         }
                     }
 
-                    if showTimeCollisionNotice {
+                    if showTimeCollisionNotice && !autoSwitch.followsSystemAppearance {
                         HStack(spacing: 6) {
                             Image(systemName: "exclamationmark.triangle.fill")
                                 .foregroundStyle(.orange)
@@ -167,9 +215,15 @@ struct CursorSettingsView: View {
                     }
                 }
 
-                Text("Pick a time and a cursor theme for each mode. MaCursor switches at those times and keeps that theme until the next one.")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
+                if autoSwitch.followsSystemAppearance {
+                    Text("Pick a cursor theme for Light and Dark mode. MaCursor follows the macOS appearance automatically.")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                } else {
+                    Text("Pick a time and a cursor theme for each mode. MaCursor switches at those times and keeps that theme until the next one.")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
             }
         }
         .formStyle(.grouped)
@@ -205,6 +259,17 @@ struct CursorSettingsView: View {
                 var rule = autoSwitch.rule(for: role)
                 rule.themeIdentifier = newValue
                 autoSwitch.setRule(rule, for: role)
+                autoSwitch.save()
+            }
+        )
+    }
+
+    private var cursorColorBinding: Binding<Color> {
+        Binding(
+            get: { Color(nsColor: CursorColorHex.color(from: autoSwitch.baseColorHex)) },
+            set: { newValue in
+                guard let hex = CursorColorHex.hex(from: NSColor(newValue)) else { return }
+                autoSwitch.baseColorHex = hex
                 autoSwitch.save()
             }
         )

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Requires **macOS 15 Sequoia** or later.
 - **Cursor Scale** — Adjust cursor size from 0.50× to 4.00× with a precision slider (0.1× steps), or type any custom value and press Enter to apply
 - **Left / Right Hand Mode** — Switch cursor orientation for left-handed or right-handed mouse usage directly from Settings
 - **Global Hotkeys** — Assign keyboard shortcuts to favorite themes for instant switching from anywhere
-- **Automatic Day / Night Switching** — Set a start time and a theme for Day mode and Night mode, and MaCursor changes your cursor on schedule
+- **Automatic Theme Switching** — Switch Day / Night themes on a schedule or map separate cursor themes to macOS Light and Dark appearance
+- **Adaptive Cursor Colors** — Recolor a theme's main fill while preserving white outlines and shadows, with optional blending toward the macOS accent color
 - **Background Helper Tool** — Lightweight login item (`macursorhelper`) that keeps shortcuts active and reapplies your theme across user switches
 - **Auto-Updates** — Built-in Sparkle integration for seamless over-the-air updates
 - **Light / Dark / System Appearance** — Full appearance mode control
@@ -98,13 +99,19 @@ The new scale takes effect immediately.
 
 ### Automatic Switching
 
-Let MaCursor change your cursor theme on a schedule:
+Let MaCursor change your cursor theme on a schedule or follow the system appearance:
 
 1. Open **MaCursor → Settings → Cursor Control** and turn on **Switch cursor automatically**. This needs the Helper Tool, which you can install from **General → Helper Tool**.
-2. Pick **AM/PM** or **24 hours** as your time format.
-3. Set a start time and a theme for **Day mode** and for **Night mode**.
+2. To follow macOS, turn on **Follow system appearance** and choose a theme for **Light** and **Dark**.
+3. To use a schedule instead, leave that option off, pick **AM/PM** or **24 hours**, then set a start time and theme for **Day mode** and **Night mode**.
 
-MaCursor switches at those times and keeps that theme until the next one. The two modes must start at different times.
+The Helper Tool reacts to appearance changes in the background and keeps the selected theme active after login, sleep, wake, and user switches.
+
+### Adaptive Cursor Colors
+
+Open **MaCursor → Settings → Cursor Control** and turn on **Custom cursor color**. Choose a base color, then optionally enable **Follow system accent color** and use **Accent adaptivity** to control how strongly the macOS accent influences the cursor.
+
+MaCursor recolors the dominant fill of the applied theme while preserving white outlines, shadows, hotspots, animation frames, and Retina representations. Generated variants are cached locally and refreshed when the source theme, chosen color, or system accent changes.
 
 ### Importing Themes
 


### PR DESCRIPTION
## What changed

- adds an optional **Follow system appearance** mode that maps separate cursor themes to macOS Light and Dark appearance
- preserves the existing time-based Day / Night schedule when system appearance following is disabled
- adds optional cursor fill recoloring with a base color, macOS accent-color following, and an adaptivity slider
- preserves white outlines, shadows, cursor metadata, hotspots, animation frames, and Retina representations
- caches generated color variants and invalidates them when the source theme or target color changes
- makes the background helper react to appearance and accent-color changes
- keeps saved automatic-switching configurations backward compatible
- adds English/German strings and README documentation

## Why

MaCursor previously supported only clock-based Day / Night switching and could not adapt a cursor theme to the current macOS appearance or accent color. Users who wanted different Light/Dark themes or an accent-matched cursor had to reapply or rebuild themes manually.

## User impact

Users can now choose Light and Dark cursor themes in **Settings → Cursor Control** and optionally recolor the active theme without modifying its original `.cursor` file. Existing schedules remain unchanged by default because all new options decode as disabled for older configurations.

## Validation

- Release build: `xcodebuild` completed with `BUILD SUCCEEDED`
- bundle validation: `codesign --verify --deep --strict` passed for the app and embedded helper
- manual Light → Dark → Light switching applied the configured themes live
- helper restart reapplied the correct theme while the main app remained closed
- generated Classic and Amber cursor variants passed property-list validation
- all 30 cursor entries and 118 image representations decoded successfully with metadata and hotspots preserved
